### PR TITLE
Updated tsconfig's and fixed missing dependency in `asset-source-template/package.json`

### DIFF
--- a/asset-source-template/package.json
+++ b/asset-source-template/package.json
@@ -9,12 +9,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/react": "^18.3.4",
     "prettier": "2.7.0",
     "typescript-plugin-css-modules": "^5.0.1"
   },
   "dependencies": {
-    "@vev/react": "^0.1.11",
-    "react": "^18.2.0"
+    "@vev/react": "^0.3.3",
+    "@vev/utils": "1.2.15"
   }
 }

--- a/brandfolder/tsconfig.json
+++ b/brandfolder/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/bynder/tsconfig.json
+++ b/bynder/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/cloudinary/tsconfig.json
+++ b/cloudinary/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/frontify/tsconfig.json
+++ b/frontify/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/pexels/tsconfig.json
+++ b/pexels/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/pixabay/tsconfig.json
+++ b/pixabay/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [

--- a/unsplash/tsconfig.json
+++ b/unsplash/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["dom", "es2020"],
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": false,
     "plugins": [


### PR DESCRIPTION

* Added `@vev/utils` version `1.2.15` in `asset-source-template/package.json`  to fix mising import error in `src/asset-source`
* Also upgraded `@vev/react` to version `^0.3.3` in `asset-source-template/package.json` 

* Changed the `module` and `moduleResolution` options to `nodenext` in the `tsconfig.json` files for the following packages to align with modern Node.js and TypeScript standards also to fix `node` value being depreciated for `node10`: `brandfolder`, `bynder`, `cloudinary`, `frontify`, `pexels`, `pixabay`, and `unsplash`. 

<img width="1138" height="611" alt="image" src="https://github.com/user-attachments/assets/2947c107-c344-47e2-b4de-99ba786c2bf5" />
