### PR TITLE
Consolidate shared functionality across plugins

### DIFF
--- a/brandfolder/package.json
+++ b/brandfolder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bynder-editor-plugin",
+  "name": "brandfolder-editor-plugin",
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@vev/utils": "^1.2.15",
-    "@vev/react": "^0.3.3"
+    "@vev/react": "^0.3.3",
+    "shared": "*"
   }
 }

--- a/brandfolder/src/settings.ts
+++ b/brandfolder/src/settings.ts
@@ -1,33 +1,14 @@
 import { BrandfolderClient } from './client';
 import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  EditorPluginAssetSourceFilterFields,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = 'global' | 'workspace' | 'team' | 'meta_fields' | null;
-
-export type EditorPluginAssetSourceFilterField = {
-  label: string;
-  value: string;
-  fields: { label: string; value: string }[];
-};
-
-export type EditorPluginAssetSourceFilterFields = EditorPluginAssetSourceFilterField[];
-
-export function getSettingsPath(url: string): settingsType {
-  try {
-    const settings = url.split('/').splice(-2)[0];
-    const type = url.split('/').splice(-1)[0];
-
-    if (
-      settings === 'settings' &&
-      (type === 'global' || type === 'workspace' || type === 'team' || type === 'meta_fields')
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
+export type { EditorPluginAssetSourceFilterFields };
 
 export async function getMetaFields(
   client: BrandfolderClient,
@@ -63,7 +44,7 @@ export async function getMetaFields(
   return metaProps;
 }
 
-export async function getSettings(type: settingsType, client: BrandfolderClient): Promise<any> {
+export async function getSettings(type: SettingsType, client: BrandfolderClient): Promise<any> {
   switch (type) {
     case 'global':
       return getSettingsForm(client);
@@ -106,17 +87,5 @@ export type RequestProperties = {
 };
 
 export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
-  try {
-    const properties = await request.json();
-
-    if (properties.assetType) {
-      properties.assetType = properties.assetType.toLowerCase();
-    }
-
-    return properties as RequestProperties;
-  } catch (e) {
-    console.log(e);
-    console.log('No request body');
-    return {};
-  }
+  return getPropertiesFromRequestBase<RequestProperties>(request, { normalizeAssetType: true });
 }

--- a/bynder/package.json
+++ b/bynder/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vev/react": "^0.1.6",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shared": "*"
   }
 }

--- a/bynder/src/settings.ts
+++ b/bynder/src/settings.ts
@@ -1,111 +1,86 @@
-import { BynderClient } from "./client";
+import { BynderClient } from './client';
 import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  EditorPluginAssetSourceFilterFields,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = "global" | "workspace" | "team" | "meta_fields" | null;
-
-export type EditorPluginAssetSourceFilterField = {
-  label: string;
-  value: string;
-  fields: { label: string; value: string }[];
-};
-export type EditorPluginAssetSourceFilterFields = EditorPluginAssetSourceFilterField[];
-
-export function getSettingsPath(url: string): settingsType {
-  try {
-    let settings = url.split("/").splice(-2)[0];
-    let type = url.split("/").splice(-1)[0];
-
-    if (
-      settings === "settings" &&
-      (type === "global" ||
-        type === "workspace" ||
-        type === "team" ||
-        type === "meta_fields")
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
+export type { EditorPluginAssetSourceFilterFields };
 
 export async function getMetaFields(
   client: BynderClient,
-  assetType: ("image" | "video" | "other")[]
+  assetType: ('image' | 'video' | 'other')[],
 ): Promise<EditorPluginAssetSourceFilterFields> {
   const metaProps: EditorPluginAssetSourceFilterFields = [];
   const allMetaProperties = await client.getAllMetaProperties(assetType);
 
-  Object.keys(allMetaProperties).forEach(
-    (key) => {
-      const metaProperty = allMetaProperties[key];
-      metaProps.push({
-        label: metaProperty.label,
-        value: metaProperty.name,
-        fields: metaProperty.options.map((option) => {
-          return {
-            label: option.label,
-            value: option.name
-          };
-        })
-      })
-    }
-  );
+  Object.keys(allMetaProperties).forEach((key) => {
+    const metaProperty = allMetaProperties[key];
+    metaProps.push({
+      label: metaProperty.label,
+      value: metaProperty.name,
+      fields: metaProperty.options.map((option) => {
+        return {
+          label: option.label,
+          value: option.name,
+        };
+      }),
+    });
+  });
 
   return metaProps;
 }
 
 export async function getSettings(
-  type: settingsType,
+  type: SettingsType,
   client: BynderClient,
-  assetType: ("image" | "video" | "other")[]
+  assetType: ('image' | 'video' | 'other')[],
 ): Promise<any> {
   switch (type) {
-    case "global":
+    case 'global':
       return getSettingsForm(client, assetType);
-    case "team":
+    case 'team':
       return getSettingsForm(client, assetType);
-    case "workspace":
+    case 'workspace':
       return getSettingsForm(client, assetType);
   }
 }
 
 async function getSettingsForm(
   client: BynderClient,
-  assetType: ("image" | "video" | "other")[]
+  assetType: ('image' | 'video' | 'other')[],
 ): Promise<{ form: VevProps[] }> {
   const allMetaProperties = await client.getAllMetaProperties(assetType);
 
-  const metaPropItems: VevProps[] = Object.keys(allMetaProperties).map(
-    (key) => {
-      const metaProperty = allMetaProperties[key];
-      metaProperty.options.unshift({label: ' ', name: null})
-      return {
-        name: metaProperty.name,
-        title: metaProperty.label,
-        type: "select",
-        options: {
-          multiselect: false,
-          display: "autocomplete",
-          items: metaProperty.options.map((option) => {
-            return {
-              label: option.label,
-              value: option.name,
-            };
-          }),
-        },
-      };
-    }
-  );
+  const metaPropItems: VevProps[] = Object.keys(allMetaProperties).map((key) => {
+    const metaProperty = allMetaProperties[key];
+    metaProperty.options.unshift({ label: ' ', name: null });
+    return {
+      name: metaProperty.name,
+      title: metaProperty.label,
+      type: 'select',
+      options: {
+        multiselect: false,
+        display: 'autocomplete',
+        items: metaProperty.options.map((option) => {
+          return {
+            label: option.label,
+            value: option.name,
+          };
+        }),
+      },
+    };
+  });
 
   return {
     form: [
       {
-        type: "object",
-        name: "property_filter",
-        title: "Filter on meta data",
+        type: 'object',
+        name: 'property_filter',
+        title: 'Filter on meta data',
         fields: [...metaPropItems],
       },
     ],
@@ -113,21 +88,11 @@ async function getSettingsForm(
 }
 
 export type RequestProperties = {
-  assetType?: "image" | "video" | "other";
+  assetType?: 'image' | 'video' | 'other';
   filter?: { field: string; value: string }[];
   property_filter?: Record<string, string | null>;
 };
 
-export async function getPropertiesFromRequest(
-  request: Request
-): Promise<RequestProperties> {
-  try {
-    const properties = await request.json();
-    properties.assetType = properties.assetType.toLowerCase();
-    return properties as RequestProperties;
-  } catch (e) {
-    console.log(e);
-    console.log("No request body");
-    return {};
-  }
+export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
+  return getPropertiesFromRequestBase<RequestProperties>(request, { normalizeAssetType: true });
 }

--- a/cloudinary/package.json
+++ b/cloudinary/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vev/react": "^0.1.5",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shared": "*"
   }
 }

--- a/cloudinary/src/cloudinary.ts
+++ b/cloudinary/src/cloudinary.ts
@@ -8,7 +8,7 @@ import {
   ProjectVideoAsset,
 } from "./vev-types";
 import { Resource } from "./types";
-import { getPropertiesFromRequest, getSettings, getPath } from "./settings";
+import { getPropertiesFromRequest, getSettings, getSettingsPath } from "./settings";
 import { getMetaFields, MetaFields } from "./metaFields";
 import { createThumbnail } from "./transforms";
 
@@ -70,7 +70,7 @@ async function handler(
   const urlSearchParams = new URLSearchParams(url.search);
   const search = urlSearchParams.get("search");
 
-  const settingType = getPath(request.url);
+  const settingType = getSettingsPath(request.url);
   const client = new Client(env.CLOUD_NAME, env.KEY, env.SECRET);
 
   // Handle settings and meta fields

--- a/cloudinary/src/settings.ts
+++ b/cloudinary/src/settings.ts
@@ -1,59 +1,37 @@
-import { VevProps } from "@vev/utils";
-import { MetaFields } from './metaFields';
+import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = "global" | "workspace" | "team" | "meta_fields" | null;
-export function getPath(url: string): settingsType {
-  try {
-    let settings = url.split("/").splice(-2)[0];
-    let type = url.split("/").splice(-1)[0];
-
-
-    if (
-      settings === "settings" &&
-      (type === "global" || type === "workspace" || type === "team" || type === "meta_fields")
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
 
 async function getSettingsForm(): Promise<{ form: VevProps[] }> {
   return {
     form: [
       {
-        name: "selfHostAssets",
-        title: "Self host assets",
-        type: "boolean",
+        name: 'selfHostAssets',
+        title: 'Self host assets',
+        type: 'boolean',
       },
     ],
   };
 }
 
-export async function getSettings(type: settingsType): Promise<any> {
+export async function getSettings(type: SettingsType): Promise<any> {
   switch (type) {
-    case "global":
+    case 'global':
       return getSettingsForm();
   }
 }
 
 export type RequestProperties = {
   selfHostAssets?: boolean;
-  assetType?: "IMAGE" | "VIDEO" | "OTHER";
+  assetType?: 'IMAGE' | 'VIDEO' | 'OTHER';
   filter?: Record<string, string>;
 };
 
-export async function getPropertiesFromRequest(
-  request: Request
-): Promise<RequestProperties> {
-  try {
-    return await request.json();
-  } catch (e) {
-    console.log(e);
-    console.log("No request body");
-    return {};
-  }
+export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
+  return getPropertiesFromRequestBase<RequestProperties>(request);
 }

--- a/frontify/package.json
+++ b/frontify/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bynder-editor-plugin",
+  "name": "frontify-editor-plugin",
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@vev/utils": "^1.2.15",
-    "@vev/react": "^0.3.3"
+    "@vev/react": "^0.3.3",
+    "shared": "*"
   }
 }

--- a/frontify/src/settings.ts
+++ b/frontify/src/settings.ts
@@ -1,33 +1,14 @@
 import { FrontifyClient } from './client';
 import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  EditorPluginAssetSourceFilterFields,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = 'global' | 'workspace' | 'team' | 'meta_fields' | null;
-
-export type EditorPluginAssetSourceFilterField = {
-  label: string;
-  value: string;
-  fields: { label: string; value: string }[];
-};
-
-export type EditorPluginAssetSourceFilterFields = EditorPluginAssetSourceFilterField[];
-
-export function getSettingsPath(url: string): settingsType {
-  try {
-    const settings = url.split('/').splice(-2)[0];
-    const type = url.split('/').splice(-1)[0];
-
-    if (
-      settings === 'settings' &&
-      (type === 'global' || type === 'workspace' || type === 'team' || type === 'meta_fields')
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
+export type { EditorPluginAssetSourceFilterFields };
 
 export async function getMetaFields(
   client: FrontifyClient,
@@ -51,7 +32,7 @@ export async function getMetaFields(
   return metaProps;
 }
 
-export async function getSettings(type: settingsType, client: FrontifyClient): Promise<any> {
+export async function getSettings(type: SettingsType, client: FrontifyClient): Promise<any> {
   switch (type) {
     case 'global':
       return getSettingsForm(client);
@@ -94,17 +75,5 @@ export type RequestProperties = {
 };
 
 export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
-  try {
-    const properties = await request.json();
-
-    if (properties.assetType) {
-      properties.assetType = properties.assetType.toLowerCase();
-    }
-
-    return properties as RequestProperties;
-  } catch (e) {
-    console.log(e);
-    console.log('No request body');
-    return {};
-  }
+  return getPropertiesFromRequestBase<RequestProperties>(request, { normalizeAssetType: true });
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "editor-plugins",
   "version": "1.0.0",
   "description": "",
+  "workspaces": [
+    "shared",
+    "bynder",
+    "brandfolder",
+    "frontify",
+    "cloudinary",
+    "pixabay",
+    "unsplash",
+    "pexels"
+  ],
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.12.2",

--- a/pexels/package.json
+++ b/pexels/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pixabay-editor-plugin",
+  "name": "pexels-editor-plugin",
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vev/react": "latest",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shared": "*"
   }
 }

--- a/pexels/src/pexels.ts
+++ b/pexels/src/pexels.ts
@@ -5,7 +5,7 @@ import {
   ProjectImageAsset,
   ProjectVideoAsset,
 } from "@vev/utils";
-import { getPath, getPropertiesFromRequest } from "./settings";
+import { getSettingsPath, getPropertiesFromRequest } from "./settings";
 
 const API_IMAGE = "https://api.pexels.com/v1/search";
 const API_IMAGE_CURATED = "https://api.pexels.com/v1/curated";
@@ -103,7 +103,7 @@ async function handler(
   const urlSearchParams = new URLSearchParams(url.search);
   const search = urlSearchParams.get("search");
 
-  const settingType = getPath(request.url);
+  const settingType = getSettingsPath(request.url);
 
   // Handle settings and meta fields
   if (settingType === "meta_fields") {

--- a/pexels/src/settings.ts
+++ b/pexels/src/settings.ts
@@ -1,58 +1,37 @@
-import { VevProps } from "@vev/utils";
+import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = "global" | "workspace" | "team" | "meta_fields" | null;
-export function getPath(url: string): settingsType {
-  try {
-    let settings = url.split("/").splice(-2)[0];
-    let type = url.split("/").splice(-1)[0];
-
-
-    if (
-      settings === "settings" &&
-      (type === "global" || type === "workspace" || type === "team" || type === "meta_fields")
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
 
 async function getSettingsForm(): Promise<{ form: VevProps[] }> {
   return {
     form: [
       {
-        name: "selfHostAssets",
-        title: "Self host assets",
-        type: "boolean",
+        name: 'selfHostAssets',
+        title: 'Self host assets',
+        type: 'boolean',
       },
     ],
   };
 }
 
-export async function getSettings(type: settingsType): Promise<any> {
+export async function getSettings(type: SettingsType): Promise<any> {
   switch (type) {
-    case "global":
+    case 'global':
       return getSettingsForm();
   }
 }
 
 export type RequestProperties = {
   selfHostAssets?: boolean;
-  assetType?: "IMAGE" | "VIDEO" | "OTHER";
+  assetType?: 'IMAGE' | 'VIDEO' | 'OTHER';
   filter?: Record<string, string>;
 };
 
-export async function getPropertiesFromRequest(
-  request: Request
-): Promise<RequestProperties> {
-  try {
-    return await request.json();
-  } catch (e) {
-    console.log(e);
-    console.log("No request body");
-    return {};
-  }
+export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
+  return getPropertiesFromRequestBase<RequestProperties>(request);
 }

--- a/pixabay/package.json
+++ b/pixabay/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vev/react": "latest",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shared": "*"
   }
 }

--- a/pixabay/src/pixabay.ts
+++ b/pixabay/src/pixabay.ts
@@ -5,7 +5,7 @@ import {
   ProjectImageAsset,
   ProjectVideoAsset,
 } from "@vev/utils";
-import { getPath, getPropertiesFromRequest } from "./settings";
+import { getSettingsPath, getPropertiesFromRequest } from "./settings";
 
 const API_IMAGE = "https://pixabay.com/api";
 const API_VIDEO = "https://pixabay.com/api/videos/";
@@ -96,7 +96,7 @@ async function handler(
   const urlSearchParams = new URLSearchParams(url.search);
   const search = urlSearchParams.get("search");
 
-  const settingType = getPath(request.url);
+  const settingType = getSettingsPath(request.url);
 
   // Handle settings and meta fields
   if (settingType === "meta_fields") {

--- a/pixabay/src/settings.ts
+++ b/pixabay/src/settings.ts
@@ -1,58 +1,37 @@
-import { VevProps } from "@vev/utils";
+import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = "global" | "workspace" | "team" | "meta_fields" | null;
-export function getPath(url: string): settingsType {
-  try {
-    let settings = url.split("/").splice(-2)[0];
-    let type = url.split("/").splice(-1)[0];
-
-
-    if (
-      settings === "settings" &&
-      (type === "global" || type === "workspace" || type === "team" || type === "meta_fields")
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
 
 async function getSettingsForm(): Promise<{ form: VevProps[] }> {
   return {
     form: [
       {
-        name: "selfHostAssets",
-        title: "Self host assets",
-        type: "boolean",
+        name: 'selfHostAssets',
+        title: 'Self host assets',
+        type: 'boolean',
       },
     ],
   };
 }
 
-export async function getSettings(type: settingsType): Promise<any> {
+export async function getSettings(type: SettingsType): Promise<any> {
   switch (type) {
-    case "global":
+    case 'global':
       return getSettingsForm();
   }
 }
 
 export type RequestProperties = {
   selfHostAssets?: boolean;
-  assetType?: "IMAGE" | "VIDEO" | "OTHER";
+  assetType?: 'IMAGE' | 'VIDEO' | 'OTHER';
   filter?: Record<string, string>;
 };
 
-export async function getPropertiesFromRequest(
-  request: Request
-): Promise<RequestProperties> {
-  try {
-    return await request.json();
-  } catch (e) {
-    console.log(e);
-    console.log("No request body");
-    return {};
-  }
+export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
+  return getPropertiesFromRequestBase<RequestProperties>(request);
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "shared",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './settings';

--- a/shared/src/settings.ts
+++ b/shared/src/settings.ts
@@ -1,0 +1,45 @@
+import { SettingsType } from './types';
+
+export function getSettingsPath(url: string): SettingsType {
+  try {
+    const settings = url.split('/').splice(-2)[0];
+    const type = url.split('/').splice(-1)[0];
+
+    if (
+      settings === 'settings' &&
+      (type === 'global' || type === 'workspace' || type === 'team' || type === 'meta_fields')
+    ) {
+      return type as SettingsType;
+    }
+
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+export interface GetPropertiesOptions {
+  normalizeAssetType?: boolean;
+}
+
+export async function getPropertiesFromRequest<T extends Record<string, unknown>>(
+  request: Request,
+  options: GetPropertiesOptions = {},
+): Promise<T> {
+  try {
+    const properties = (await request.json()) as T;
+
+    if (
+      options.normalizeAssetType &&
+      'assetType' in properties &&
+      typeof properties.assetType === 'string'
+    ) {
+      (properties as Record<string, unknown>).assetType = properties.assetType.toLowerCase();
+    }
+
+    return properties;
+  } catch (e) {
+    console.log('No request body');
+    return {} as T;
+  }
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,0 +1,9 @@
+export type SettingsType = 'global' | 'workspace' | 'team' | 'meta_fields' | null;
+
+export type EditorPluginAssetSourceFilterField = {
+  label: string;
+  value: string;
+  fields: { label: string; value: string }[];
+};
+
+export type EditorPluginAssetSourceFilterFields = EditorPluginAssetSourceFilterField[];

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/unsplash/package.json
+++ b/unsplash/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vev/react": "^0.1.6",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shared": "*"
   }
 }

--- a/unsplash/src/settings.ts
+++ b/unsplash/src/settings.ts
@@ -1,58 +1,37 @@
-import { VevProps } from "@vev/utils";
+import { VevProps } from '@vev/utils';
+import {
+  SettingsType,
+  getSettingsPath,
+  getPropertiesFromRequest as getPropertiesFromRequestBase,
+} from 'shared';
 
-type settingsType = "global" | "workspace" | "team" | "meta_fields" | null;
-export function getPath(url: string): settingsType {
-  try {
-    let settings = url.split("/").splice(-2)[0];
-    let type = url.split("/").splice(-1)[0];
-
-
-    if (
-      settings === "settings" &&
-      (type === "global" || type === "workspace" || type === "team" || type === "meta_fields")
-    ) {
-      return type;
-    }
-
-    return null;
-  } catch (e) {
-    return null;
-  }
-}
+export { getSettingsPath };
 
 async function getSettingsForm(): Promise<{ form: VevProps[] }> {
   return {
     form: [
       {
-        name: "selfHostAssets",
-        title: "Self host assets",
-        type: "boolean",
+        name: 'selfHostAssets',
+        title: 'Self host assets',
+        type: 'boolean',
       },
     ],
   };
 }
 
-export async function getSettings(type: settingsType): Promise<any> {
+export async function getSettings(type: SettingsType): Promise<any> {
   switch (type) {
-    case "global":
+    case 'global':
       return getSettingsForm();
   }
 }
 
 export type RequestProperties = {
   selfHostAssets?: boolean;
-  assetType?: "IMAGE" | "VIDEO" | "OTHER";
+  assetType?: 'IMAGE' | 'VIDEO' | 'OTHER';
   filter?: Record<string, string>;
 };
 
-export async function getPropertiesFromRequest(
-  request: Request
-): Promise<RequestProperties> {
-  try {
-    return await request.json();
-  } catch (e) {
-    console.log(e);
-    console.log("No request body");
-    return {};
-  }
+export async function getPropertiesFromRequest(request: Request): Promise<RequestProperties> {
+  return getPropertiesFromRequestBase<RequestProperties>(request);
 }

--- a/unsplash/src/unsplash.ts
+++ b/unsplash/src/unsplash.ts
@@ -5,7 +5,7 @@ import {
   ProjectAsset,
   ProjectImageAsset,
 } from "@vev/utils";
-import { getPath, getPropertiesFromRequest } from "./settings";
+import { getSettingsPath, getPropertiesFromRequest } from "./settings";
 
 const API = "https://api.unsplash.com/";
 
@@ -54,7 +54,7 @@ async function handler(
   const urlSearchParams = new URLSearchParams(url.search);
   const search = urlSearchParams.get("search");
 
-  const settingType = getPath(request.url);
+  const settingType = getSettingsPath(request.url);
 
   // Handle settings and meta fields
   if (settingType === "meta_fields") {


### PR DESCRIPTION
## Summary
- Extract duplicated code into new `shared` package
- Add npm workspaces configuration
- Standardize function naming (`getPath` → `getSettingsPath`)
- Fix incorrect package names in brandfolder, frontify, pexels

Removes ~165 lines of duplicated code across 7 plugins.

## Changes
- **New:** `shared/` package with common utilities (`getSettingsPath`, `getPropertiesFromRequest`, shared types)
- **Updated:** All plugin settings.ts files to import from shared
- **Fixed:** Package name conflicts (brandfolder, frontify, pexels had wrong names)

## Test plan
- [ ] Run `npm install` at root
- [ ] Verify each plugin compiles: `npx tsc --noEmit --skipLibCheck`
- [ ] Test one plugin with `vev start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)